### PR TITLE
Plugin channel API in NMP (+ Forge)

### DIFF
--- a/src/createClient.js
+++ b/src/createClient.js
@@ -10,6 +10,8 @@ var states = require("./states");
 var debug = require("./debug");
 var UUID = require('uuid-1345');
 var fml = require('./fml');
+var IncomingPluginChannels = require('./pluginChannels').IncomingPluginChannels;
+var OutgoingPluginChannels = require('./pluginChannels').OutgoingPluginChannels;
 
 module.exports=createClient;
 
@@ -48,6 +50,8 @@ function createClient(options) {
   var client = new Client(false,version.majorVersion);
   client.forge = options.forge;
   client.forgeMods = options.forgeMods;
+  client.incomingPluginChannels = new IncomingPluginChannels(client);
+  client.outgoingPluginChannels = new OutgoingPluginChannels(client);
   client.on('connect', onConnect);
   if(keepAlive) client.on('keep_alive', onKeepAlive);
   client.once('encryption_begin', onEncryptionKeyRequest);

--- a/src/fml.js
+++ b/src/fml.js
@@ -158,10 +158,7 @@ function writeAck(client, phase) {
     discriminator: 'HandshakeAck', // HandshakeAck,
     phase: phase
   });
-  client.write('custom_payload', {
-    channel: 'FML|HS',
-    data: ackData
-  });
+  client.outgoingPluginChannels.write('FML|HS', ackData);
 }
 
 var FMLHandshakeClientState = {
@@ -187,30 +184,21 @@ function fmlHandshakeStep(client, data)
         // TODO: support higher protocols, if they change
       }
 
-      client.write('custom_payload', {
-        channel: 'REGISTER',
-        data: new Buffer(['FML|HS', 'FML', 'FML|MP', 'FML', 'FORGE'].join('\0'))
-      });
+      client.outgoingPluginChannels.register('FML|HS', 'FML', 'FML|MP', 'FML', 'FORGE');
 
       var clientHello = proto.createPacketBuffer('FML|HS', {
         discriminator: 'ClientHello',
         fmlProtocolVersion: parsed.data.fmlProtocolVersion
       });
 
-      client.write('custom_payload', {
-        channel: 'FML|HS',
-        data: clientHello
-      });
+      client.outgoingPluginChannels.write('FML|HS', clientHello);
 
       debug('Sending client modlist');
       var modList = proto.createPacketBuffer('FML|HS', {
         discriminator: 'ModList',
         mods: client.forgeMods || []
       });
-      client.write('custom_payload', {
-        channel: 'FML|HS',
-        data: modList
-      });
+      client.outgoingPluginChannels.write('FML|HS', modList);
       writeAck(client, FMLHandshakeClientState.WAITINGSERVERDATA);
       client.fmlHandshakeState = FMLHandshakeClientState.WAITINGSERVERDATA;
       break;

--- a/src/pluginChannels.js
+++ b/src/pluginChannels.js
@@ -1,0 +1,69 @@
+var EventEmitter = require('events').EventEmitter;
+
+function serializeChannelList(channels) {
+  return new Buffer(channels.join('\0'));
+}
+
+function parseChannelList(buffer) {
+  return buffer.toString().split('\0');
+}
+
+class PluginChannels extends EventEmitter {
+  constructor(client) {
+    super();
+    this.client = client;
+    this.channels = [];
+  }
+}
+
+class IncomingPluginChannels extends PluginChannels {
+  constructor(client) {
+    super(client);
+
+    client.on('custom_payload', (packet) => {
+      client.incomingPluginChannels.emit(packet.channel, packet.data);
+
+      if (packet.channel === 'REGISTER') {
+        parseChannelList(packet.data).forEach((channel) => {
+          this.channels.push(channel);
+        });
+      } else if (packet.channel === 'UNREGISTER') {
+        parseChannelList(packet.data).forEach((channel) => {
+          this.channels.pop(channel);
+        });
+      }
+    });
+  }
+}
+
+class OutgoingPluginChannels extends PluginChannels {
+  constructor(client) {
+    super(client);
+  }
+
+  write(channel, data) {
+    this.client.write('custom_payload', {
+      channel: channel,
+      data: data
+    });
+  }
+
+  register(...channels) {
+    this.write('REGISTER', serializeChannelList(channels));
+    this.channels.forEach((channel) => {
+      this.channels.push(channel);
+    });
+  }
+
+  unregister(...channels) {
+    this.write('UNREGISTER', serializeChannelList(channels));
+    this.channels.forEach((channel) => {
+      this.channels.pop(channel);
+    });
+  }
+}
+
+module.exports = {
+  IncomingPluginChannels,
+  OutgoingPluginChannels
+};


### PR DESCRIPTION
Adds support for plugin registering, unregistering, reading from, and writing to plugin channels

Note: this PR is on top of https://github.com/PrismarineJS/node-minecraft-protocol/pull/326 Forge client support, in order to demonstrate a practical use case of this API - may need to be rebased afterwards, should be revisited after

Related: https://github.com/PrismarineJS/mineflayer/issues/361 Plugin channel API for mineflayer
